### PR TITLE
Introduce nix to build and run package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ If the installation build succeeded, you should be able to launch the applicatio
 OpenRiichi requires the `Data` folder (found inside the `bin` folder) to be in the one of the search directories. OpenRiichi will add the `OpenRiichi` subdirectory of the default data directory of the OS (usually `/usr/share/OpenRiichi`) to the search path, along with the the current working directory and the executable directory.
 An additional search path can be added during runtime by running OpenRiichi with the `--search-directory some_custom_directory` flag.
 
+### Using Nix (flakes enabled)
+
+This repository includes a `flake.nix` hence you can automatically build and run it with
+
+```bash
+git clone https://github.com/FluffyStuff/OpenRiichi.git
+cd OpenRiichi
+nix flake update # optional: if you want to update `flake.lock`
+nix run .
+```
+
 ## IDE
 
 The preferred editor to use is [Visual Studio Code](https://code.visualstudio.com).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If the installation build succeeded, you should be able to launch the applicatio
 OpenRiichi requires the `Data` folder (found inside the `bin` folder) to be in the one of the search directories. OpenRiichi will add the `OpenRiichi` subdirectory of the default data directory of the OS (usually `/usr/share/OpenRiichi`) to the search path, along with the the current working directory and the executable directory.
 An additional search path can be added during runtime by running OpenRiichi with the `--search-directory some_custom_directory` flag.
 
-### Using Nix (flakes enabled)
+### Using Nix (flakes enabled) on Linux x86
 
 This repository includes a `flake.nix` hence you can automatically build and run it with
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "open-riichi": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657618982,
+        "narHash": "sha256-ICifjbAFeBsDJZepcQhCQqgOQnFW6L6i4ufG3sCprxg=",
+        "ref": "refs/heads/master",
+        "rev": "cf3f6e53bc3c10547c579bd1f4dda5bea8b3a7d0",
+        "revCount": 83,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/FluffyStuff/OpenRiichi"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/FluffyStuff/OpenRiichi"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "open-riichi": "open-riichi"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
           SDL2_image
           SDL2_mixer
           ninja
-          git
         ];
         buildPhase = ''
           mkdir -p $out

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "OpenRiichi: An open source riichi mahjong client";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    open-riichi = {
+      url = "git+https://github.com/FluffyStuff/OpenRiichi?submodules=1";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      open-riichi,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      open-richii-drv = pkgs.stdenv.mkDerivation {
+        name = "OpenRiichi";
+        src = open-riichi;
+        nativeBuildInputs = with pkgs; [
+          vala
+          meson
+          cmake
+          pkg-config
+          glib
+          libgee
+          gtk3
+          glew
+          SDL2_image
+          SDL2_mixer
+          ninja
+          git
+        ];
+        buildPhase = ''
+          mkdir -p $out
+          meson setup build $src -Dbuildtype=release --prefix=$out
+          ninja -C build
+        '';
+        installPhase = ''
+          ninja -C build install
+          mkdir -p $out/bin
+          mv build/OpenRiichi $out/bin
+        '';
+      };
+    in
+    {
+      apps.${system} = rec {
+        OpenRiichi = {
+          type = "app";
+          program = "${open-richii-drv}/bin/OpenRiichi";
+        };
+        default = OpenRiichi;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       open-riichi,
       ...
@@ -48,10 +49,15 @@
       };
     in
     {
+      packages.${system} = rec {
+        OpenRiichi = open-richii-drv;
+        default = OpenRiichi;
+      };
+
       apps.${system} = rec {
         OpenRiichi = {
           type = "app";
-          program = "${open-richii-drv}/bin/OpenRiichi";
+          program = "${self.packages.${system}.OpenRiichi}/bin/OpenRiichi";
         };
         default = OpenRiichi;
       };


### PR DESCRIPTION
This PR introduces Nix tools `flake.nix` and its lockfile. This way one can easily build the project and run it as specified in the `README.md`

I quickly tested it on NixOS unstable and Ubuntu 22.04. It builds and run without any errors.

Since it is not merged yet, you can try it with

```bash
nix run "git+https://github.com/rx342/OpenRiichi?submodules=1"#OpenRiichi
```