### PR TITLE
Fix build failure with GCC-14 due to int-to-pointer cast

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ subdir('Engine')
 
 dataDir = get_option('prefix') / get_option('datadir') / 'OpenRiichi'
 add_project_arguments('-DOPENRIICHI_SEARCH_DIR="' + dataDir +  '"', language: 'c')
+add_project_arguments('-Wno-int-conversion', language : 'c')
 
 dependencies = [
     valac.find_library('os', dirs: meson.current_source_dir() + '/vapi', required: false)


### PR DESCRIPTION
GCC14 turned an implicit int-to-pointer cast from a warning to an error (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106416).
This happens here, as the glVertexAttribPointer in [Engine/Rendering/OpenGLRenderer/OpenGLRenderer.vala#L341](https://github.com/FluffyStuff/Engine/blob/0bd410550600a2a0858ca327576bdd32116da188/Rendering/OpenGLRenderer/OpenGLRenderer.vala#L341C13-L345C34) passes the offset as an int, whereas the C-side header is a void*.
Compiles and runs fine if the error is silenced, so it's a quick-and-dirty but functional fix to just build it as such.